### PR TITLE
Use `operator fun` not `interface` for comparison

### DIFF
--- a/src/commonMain/kotlin/io/github/kevincianfarini/alchemist/internal/SaturatingLong.kt
+++ b/src/commonMain/kotlin/io/github/kevincianfarini/alchemist/internal/SaturatingLong.kt
@@ -14,7 +14,7 @@ import kotlin.math.sign
  * LLVM for more details.
  */
 @JvmInline
-internal value class SaturatingLong(val rawValue: Long) : Comparable<SaturatingLong> {
+internal value class SaturatingLong(val rawValue: Long) {
 
     operator fun plus(other: SaturatingLong): SaturatingLong = when {
         isInfinite() && isPositive() && other.isInfinite() && other.isPositive() -> POSITIVE_INFINITY
@@ -109,7 +109,7 @@ internal value class SaturatingLong(val rawValue: Long) : Comparable<SaturatingL
         return this % SaturatingLong(other)
     }
 
-    override fun compareTo(other: SaturatingLong): Int {
+    operator fun compareTo(other: SaturatingLong): Int {
         return rawValue.compareTo(other.rawValue)
     }
 


### PR DESCRIPTION
Using it through the interface would cause boxing. This isn't done today, but implementing it makes it possible.